### PR TITLE
Fix visitor logging authorization flow

### DIFF
--- a/cloudfunctions/addVisitorRecord/index.js
+++ b/cloudfunctions/addVisitorRecord/index.js
@@ -1,48 +1,104 @@
 const cloud = require('wx-server-sdk')
+
 cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV }) // 使用当前云环境
+
 const db = cloud.database()
+const _ = db.command
 const visitor_records = db.collection('visitor_records')
 
+const formatUserInfo = (userInfo = {}) => {
+  if (!userInfo || typeof userInfo !== 'object') {
+    return {}
+  }
+
+  const allowKeys = ['avatarUrl', 'nickName', 'gender', 'city', 'province', 'country', 'language']
+  return allowKeys.reduce((acc, key) => {
+    if (userInfo[key] !== undefined && userInfo[key] !== null) {
+      acc[key] = userInfo[key]
+    }
+    return acc
+  }, {})
+}
+
 exports.main = async (event) => {
-  console.log("event", event)
-  const { visitData, userInfo, remark, _id } = event
-  
-  // 如果提供了 id，则执行更新操作，否则执行添加操作
+  const { visitData = {}, userInfo, remark, _id, shouldIncrement = true } = event
+  const wxContext = cloud.getWXContext()
+  const now = db.serverDate()
+  const incrementValue = shouldIncrement ? 1 : 0
+
   try {
-    let result
+    const safeVisitData = visitData && typeof visitData === 'object' ? visitData : {}
+    const formattedUser = formatUserInfo(userInfo)
+    const basePayload = Object.assign({}, safeVisitData, formattedUser, {
+      openid: wxContext.OPENID,
+      appid: wxContext.APPID,
+      unionid: wxContext.UNIONID || '',
+      visitTime: now,
+      updateTime: now
+    })
+
+    if (remark !== undefined && remark !== null) {
+      basePayload.remark = remark
+    }
+
+    if (Object.prototype.hasOwnProperty.call(basePayload, 'authorized')) {
+      basePayload.authorized = Boolean(basePayload.authorized)
+    }
+
+    // 优先按照传入的 _id 更新
     if (_id) {
-      // 更新操作
-      result = await visitor_records.doc(_id).update({
-        data: {
-          ...visitData,
-          ...userInfo,
-          remark: remark || '',
-          updateTime: db.serverDate()  // 更新操作时更新 `updateTime`
-        }
+      const updateResult = await visitor_records.doc(_id).update({
+        data: Object.assign({}, basePayload, {
+          visitCount: _.inc(incrementValue)
+        })
       })
+
       return {
         success: true,
-        data: result,
+        data: updateResult,
+        recordId: _id,
         message: '更新成功'
       }
-    } else {
-      // 添加操作
-      result = await visitor_records.add({
-        data: {
-          ...visitData,
-          ...userInfo,
-          remark: remark || '',
-          createTime: db.serverDate(),
-          updateTime: db.serverDate()
-        }
+    }
+
+    // 若没有传入 _id，则尝试使用 openid 查询已有记录
+    const existingRecord = await visitor_records
+      .where({ openid: wxContext.OPENID })
+      .limit(1)
+      .get()
+
+    if (existingRecord.data.length) {
+      const recordId = existingRecord.data[0]._id
+      const updateResult = await visitor_records.doc(recordId).update({
+        data: Object.assign({}, basePayload, {
+          visitCount: _.inc(incrementValue)
+        })
       })
+
       return {
         success: true,
-        data: result,
-        message: '添加成功'
+        data: updateResult,
+        recordId,
+        message: '更新成功'
       }
     }
+
+    // 新建访客记录
+    const createResult = await visitor_records.add({
+      data: Object.assign({}, basePayload, {
+        visitCount: 1,
+        createTime: now
+      })
+    })
+
+    return {
+      success: true,
+      data: createResult,
+      recordId: createResult._id,
+      message: '添加成功'
+    }
   } catch (error) {
+    console.error('记录访客失败', error)
     return {
       success: false,
       message: error.message

--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -38,75 +38,22 @@ App({
 
     // 小程序启动时，初始化云开发环境
     onLaunch(options) {
-        console.log("options", options)
         !this.globalData.isRemoved && wx.cloud.init({
             env: 'cloud1-7gptyc1428d9b296', // 云开发环境ID，在云开发控制台里可以查看
             traceUser: true
         })
-        const db = wx.cloud.database()
-        const { scene, path, query, referrerInfo } = options
 
-
-
-        // 获取设备信息
-        const systemInfo = wx.getSystemInfoSync()
-
-        // 构建访问记录数据
-        const visitData = {
-            visitTime: new Date(),
-            pagePath: path || '首页',
-            scene: scene || 1001,
-            sceneInfo: this.getSceneInfo(scene),
-            deviceInfo: {
-                model: systemInfo.model,
-                system: systemInfo.system,
-                platform: systemInfo.platform,
-                SDKVersion: systemInfo.SDKVersion
-            },
-            createTime: db.serverDate()
+        const storedRecordId = wx.getStorageSync('recordId')
+        if (storedRecordId) {
+            this.globalData.recordId = storedRecordId
         }
 
-        // 如果有场景参数，添加场景信息
-        if (query) {
-            visitData.queryParams = query
+        const storedProfile = wx.getStorageSync('userProfile')
+        if (storedProfile && typeof storedProfile === 'object') {
+            this.globalData.userInfo = storedProfile
         }
 
-        // 如果有来源信息
-        if (referrerInfo) {
-            visitData.referrerInfo = referrerInfo
-        }
-
-
-        // 添加访客记录的云函数
-        wx.cloud.callFunction({
-            name: 'addVisitorRecord',
-            data: {
-                _id: null,
-                visitData: {
-                    ...visitData
-                },
-                userInfo: {
-                    "openId": "OPENID",
-                    "nickName": "NICKNAME",
-                    "gender": "GENDER",
-                    "city": "CITY",
-                    "province": "PROVINCE",
-                    "country": "COUNTRY",
-                    "avatarUrl": "AVATARURL",
-                    "unionId": "UNIONID",
-                }
-            }
-        }).then((res)=>{
-          console.log("res", res)
-          if(res.result.data.errMsg === 'collection.add:ok'){
-            console.log("res", res.result.data._id)
-            this.globalData.recordId = res.result.data._id
-            wx.setStorageSync('recordId', res.result.data._id);
-
-          }
-          
-        })
-
+        this.globalData.launchOptions = options
     },
 
     // 小程序可见时，判断是否为单页模式

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -11,6 +11,8 @@ Page({
     data: {
         ...APP.globalData,
         userInfo: null,
+        hasAuthorized: false,
+        showAuthPrompt: false,
         isManager: false, // 当前用户是否为管理员
         musicIsPaused: false, // 是否暂停背景音乐
         activeIdx: isRemoved ? 0 : -1, // 祝福语轮播用，当前显示的祝福语索引值
@@ -150,13 +152,17 @@ Page({
               })
 
 
-        
+
         this.timer = null
         this.music = null
         this.isSubmit = false
+        this.recording = false
+        this.pendingRecord = null
+
+        this.initUserInfo()
 
         if (!isRemoved) {
-          
+
             const db = wx.cloud.database()
             db.collection('surveys').get({
                 success: res => {
@@ -208,78 +214,17 @@ Page({
 
     // 小程序可见时，拉取祝福语，并设置定时器每20s重新拉取一次祝福语
     onShow() {
-      wx.showModal({
-        title: '温馨提示',
-        content: '亲，授权微信登录后才能正常使用小程序功能',
-        success: (res)=> {
-          console.log(0)
-          console.log(res)
-          //如果用户点击了确定按钮
-          if (res.confirm) {
-            wx.getUserProfile({
-              desc: '获取你的昵称、头像、地区及性别',
-              success: res => {
-                console.log(res);
-                this.setData({userInfo: res.userInfo})
-            //     this.setData({
-            //       form: {
-            //           ...this.data.form,
-            //           name: res.userInfo.nickName,
-            //           avatarUrl: res.userInfo.avatarUrl
-            //       }
-            //   });
-                console.log(1);
-              },
-              fail: res => {
-                console.log(2);
-                console.log(res)
-                //拒绝授权
-                wx.showToast({
-                  title: '您拒绝了请求,不能正常使用小程序',
-                  icon: 'error',
-                  duration: 2000
-                });
-                return;
-              }
-            });
-          } else if (res.cancel) {
-            //如果用户点击了取消按钮
-            console.log(3);
-            wx.showToast({
-              title: '您拒绝了请求,不能正常使用小程序',
-              icon: 'error',
-              duration: 2000
-            });
-            return;
-          }
-        }
-      });
-      
         if (!isRemoved) {
             this.getGreetings()
 
             this.timer === null && (this.timer = setInterval(() => this.getGreetings(), 20000));
         }
-        const recordId = wx.getStorageSync('recordId') || '';
-        console.log("APP.globalData.recordId", recordId, this.userInfo)
 
-        wx.cloud.callFunction({
-          name: 'addVisitorRecord',
-          data: {
-            _id: recordId,
-            userInfo: {
-              nickName: 'John Doe',
-              openId: '123456789'
-            },
-          },
-          success(res) {
-            console.log('Success:', res)
-          },
-          fail(err) {
-            console.log('Error:', err)
-          }
-        })
-        
+        if (!this.data.hasAuthorized && !this.data.showAuthPrompt) {
+            this.setData({ showAuthPrompt: true })
+        }
+
+        this.recordVisit()
     },
 
     // 小程序不可见时，取消自动拉取祝福语定时器
@@ -513,11 +458,192 @@ Page({
             url: `../record/index?isManager=${this.data.isManager}`
         })
     },
+    handleAuthorize() {
+        if (typeof wx.getUserProfile !== 'function') {
+            wx.showToast({
+                title: '当前微信版本过低，无法授权',
+                icon: 'none'
+            })
+            return
+        }
+        wx.getUserProfile({
+            desc: '用于展示访客头像和昵称，并同步访客记录',
+            success: (res) => {
+                const userInfo = res.userInfo || {}
+                const storedForm = Object.assign({}, this.data.form || {})
+
+                if (!storedForm.name && userInfo.nickName) {
+                    storedForm.name = userInfo.nickName
+                }
+
+                if (!storedForm.avatarUrl && userInfo.avatarUrl) {
+                    storedForm.avatarUrl = userInfo.avatarUrl
+                }
+
+                wx.setStorageSync('userProfile', userInfo)
+                APP.globalData.userInfo = userInfo
+
+                this.setData({
+                    userInfo,
+                    hasAuthorized: true,
+                    showAuthPrompt: false,
+                    form: storedForm
+                }, () => {
+                    this.recordVisit({ force: true, increment: false })
+                })
+            },
+            fail: () => {
+                wx.showToast({
+                    title: '授权已取消',
+                    icon: 'none'
+                })
+            }
+        })
+    },
+    initUserInfo() {
+        const storedProfile = wx.getStorageSync('userProfile')
+        const cached = APP.globalData.userInfo || (typeof storedProfile === 'object' ? storedProfile : null)
+        if (cached && typeof cached === 'object' && Object.keys(cached).length) {
+            const storedForm = Object.assign({}, this.data.form || {})
+
+            if (!storedForm.name && cached.nickName) {
+                storedForm.name = cached.nickName
+            }
+
+            if (!storedForm.avatarUrl && cached.avatarUrl) {
+                storedForm.avatarUrl = cached.avatarUrl
+            }
+
+            this.setData({
+                userInfo: cached,
+                hasAuthorized: true,
+                showAuthPrompt: false,
+                form: storedForm
+            })
+            APP.globalData.userInfo = cached
+        } else {
+            const canAuthorize = typeof wx.getUserProfile === 'function'
+            this.setData({
+                hasAuthorized: false,
+                showAuthPrompt: canAuthorize
+            })
+        }
+    },
+    recordVisit(options = {}) {
+        if (APP.globalData.isRemoved) {
+            return
+        }
+
+        if (!wx.cloud || typeof wx.cloud.callFunction !== 'function') {
+            console.warn('云开发未初始化，无法记录访客信息')
+            return
+        }
+
+        let force = false
+        let increment = true
+
+        if (typeof options === 'boolean') {
+            force = options
+        } else if (options && typeof options === 'object') {
+            force = !!options.force
+            if (options.increment === false) {
+                increment = false
+            }
+        }
+
+        if (this.recording) {
+            if (force) {
+                this.pendingRecord = { force: false, increment }
+            }
+            return
+        }
+
+        let launchOptions = {}
+        try {
+            launchOptions = wx.getLaunchOptionsSync ? wx.getLaunchOptionsSync() : {}
+        } catch (error) {
+            launchOptions = {}
+        }
+
+        if ((!launchOptions || Object.keys(launchOptions).length === 0) && APP.globalData.launchOptions) {
+            launchOptions = APP.globalData.launchOptions
+        }
+
+        const sceneDescription = typeof APP.getSceneInfo === 'function'
+            ? APP.getSceneInfo(launchOptions.scene)
+            : ''
+
+        let systemInfo = {}
+        try {
+            systemInfo = wx.getSystemInfoSync()
+        } catch (error) {
+            systemInfo = {}
+        }
+
+        const visitData = {
+            sceneInfo: {
+                scene: launchOptions.scene,
+                path: launchOptions.path,
+                query: launchOptions.query || {},
+                referrerInfo: launchOptions.referrerInfo || {},
+                description: sceneDescription
+            },
+            deviceInfo: {
+                brand: systemInfo.brand,
+                model: systemInfo.model,
+                system: systemInfo.system,
+                version: systemInfo.version,
+                platform: systemInfo.platform,
+                language: systemInfo.language
+            },
+            pagePath: launchOptions.path || 'pages/index/index',
+            authorized: this.data.hasAuthorized,
+            clientTime: new Date().toISOString()
+        }
+
+        const recordId = wx.getStorageSync('recordId') || ''
+        const userInfo = this.data.userInfo || {}
+        const formData = this.data.form || {}
+        const fallbackName = formData.name || '未留名访客'
+        const fallbackAvatar = formData.avatarUrl || ''
+
+        const payloadUserInfo = Object.assign({}, userInfo, {
+            nickName: userInfo.nickName || fallbackName,
+            avatarUrl: userInfo.avatarUrl || fallbackAvatar
+        })
+
+        this.recording = true
+        wx.cloud.callFunction({
+            name: 'addVisitorRecord',
+            data: {
+                _id: recordId || undefined,
+                visitData,
+                userInfo: payloadUserInfo,
+                shouldIncrement: increment
+            }
+        }).then((res) => {
+            const { result } = res || {}
+            if (result && result.success && result.recordId) {
+                wx.setStorageSync('recordId', result.recordId)
+                APP.globalData.recordId = result.recordId
+            }
+        }).catch((error) => {
+            console.error('记录访客失败', error)
+        }).finally(() => {
+            this.recording = false
+            if (this.pendingRecord) {
+                const pendingOptions = this.pendingRecord
+                this.pendingRecord = null
+                this.recordVisit(pendingOptions)
+            }
+        })
+    },
     onChooseAvatar(e) {
-      const { avatarUrl } = e.detail 
+      const { avatarUrl } = e.detail
       this.setData({
         'form.avatarUrl':avatarUrl,
       })
+      this.recordVisit({ force: true, increment: false })
     }
-      
+
 })

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -31,6 +31,11 @@
     </view>
 </view>
 
+<view wx:if="{{ showAuthPrompt }}" class="auth-banner">
+    <view class="auth-text">授权后可同步头像昵称并记录访客信息，方便后续查看。</view>
+    <button class="auth-btn" bindtap="handleAuthorize">微信快捷授权</button>
+</view>
+
 <view class="tc lh21 mb58">
     <view>hi~亲爱的你~</view>
     <view>当收到这封请柬的时候</view>
@@ -227,7 +232,7 @@
         <view>
             <textarea type="text" placeholder="祝福语，可以上墙哦~" name="greeting" value="{{ form.greeting }}" placeholder-class="form-input-placeholder" maxlength="140" disable-default-padding />
         </view>
-        <button form-type="submit" open-type="getUserInfo" >{{ form.name ? '更新' : '提交' }}</button>
+        <button form-type="submit">{{ form.name ? '更新' : '提交' }}</button>
     </view>
 </form>
 

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -131,6 +131,35 @@
     align-items: flex-end;
 }
 
+.auth-banner {
+    margin: 0 40rpx 60rpx;
+    padding: 24rpx 28rpx;
+    background: linear-gradient(135deg, #f3f9ff, #fff);
+    border-radius: 20rpx;
+    box-shadow: 0 8rpx 24rpx rgba(39, 92, 255, 0.08);
+}
+
+.auth-text {
+    font-size: 26rpx;
+    color: #344563;
+    line-height: 1.6;
+}
+
+.auth-btn {
+    margin-top: 20rpx;
+    background-color: #07c160;
+    color: #fff;
+    border-radius: 999rpx;
+    font-size: 28rpx;
+    padding: 12rpx 0;
+    width: 100%;
+    font-weight: 600;
+}
+
+.auth-btn::after {
+    border: none;
+}
+
 .music-status {
     width: 32rpx;
     height: 22rpx;

--- a/miniprogram/pages/record/index.wxml
+++ b/miniprogram/pages/record/index.wxml
@@ -23,14 +23,14 @@
 
     <!-- 统计信息 -->
     <view class="stats">
-      <text class="welcome-text">欢迎，{{userInfo.name}}</text>
-      <text class="stats-text">共{{visitorList.length}}条记录</text>
+      <text class="welcome-text">欢迎，{{userInfo && userInfo.name ? userInfo.name : '管理员'}}</text>
+      <text class="stats-text">共{{totalCount}}条记录</text>
     </view>
 
     <!-- 访客列表 -->
-    <scroll-view 
-      class="record-list" 
-      scroll-y 
+    <scroll-view
+      class="record-list"
+      scroll-y
       bindscrolltolower="onReachBottom"
     >
       <view wx:if="{{visitorList.length === 0 && !loading}}" class="empty">
@@ -40,16 +40,39 @@
 
       <view wx:for="{{visitorList}}" wx:key="_id" class="record-item">
         <view class="item-header">
-          <text class="visitor-name">{{item.sceneInfo}}</text>
-          <text class="visit-time">{{formatTime(item.visitTime)}}</text>
+          <image class="avatar" src="{{item.avatarUrl || defaultAvatar}}" mode="aspectFill"></image>
+          <view class="header-main">
+            <text class="visitor-name">{{item.nickName || '未授权访客'}}</text>
+            <text class="visit-time">最近访问：{{formatTime(item.visitTime)}}</text>
+          </view>
+          <view class="tag-group">
+            <view wx:if="{{item.visitCount}}" class="visit-count">第{{item.visitCount}}次</view>
+            <view wx:if="{{item.authorized}}" class="auth-tag">已授权</view>
+          </view>
         </view>
+
         <view class="item-content">
-          <text class="purpose">头像：{{item.avatarUrl}}</text>
-          <text class="contact">昵称：{{item.nickName}}</text>
-          <text wx:if="{{item.deviceInfo}}" class="remark">备注：{{stringify(item.deviceInfo)}}</text>
+          <view class="info-row">
+            <text class="label">访问入口</text>
+            <text class="value">{{formatSceneInfo(item.sceneInfo)}}</text>
+          </view>
+          <view class="info-row">
+            <text class="label">设备信息</text>
+            <text class="value">{{formatDeviceInfo(item.deviceInfo)}}</text>
+          </view>
+          <view class="info-row" wx:if="{{item.clientTime}}">
+            <text class="label">客户端</text>
+            <text class="value">{{formatTime(item.clientTime)}}</text>
+          </view>
+          <view class="info-row" wx:if="{{item.remark}}">
+            <text class="label">备注</text>
+            <text class="value">{{item.remark}}</text>
+          </view>
         </view>
+
         <view class="item-footer">
-          <text class="create-time">记录时间：{{formatTime(item.createTime)}}</text>
+          <text class="create-time">首次访问：{{formatTime(item.createTime)}}</text>
+          <text class="create-time">最近更新：{{formatTime(item.updateTime || item.visitTime)}} </text>
           <text class="delete-btn" bindtap="deleteRecord" data-id="{{item._id}}">删除</text>
         </view>
       </view>

--- a/miniprogram/pages/record/index.wxss
+++ b/miniprogram/pages/record/index.wxss
@@ -85,76 +85,118 @@
 
 /* 访客列表 */
 .record-list {
-  max-height: 600rpx;
+  height: calc(100vh - 320rpx);
   overflow-y: auto;
-  padding-bottom: 60rpx; /* 为了scroll-view添加空间 */
+  padding: 0 16rpx 60rpx;
 }
 
 .record-item {
   background-color: #fff;
   margin: 12rpx 0;
-  padding: 16rpx;
-  border-radius: 12rpx;
-  box-shadow: 0 3rpx 10rpx rgba(0, 0, 0, 0.05);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.record-item:hover {
-  transform: translateY(-5rpx);
-  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.1);
+  padding: 24rpx;
+  border-radius: 16rpx;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.06);
 }
 
 .item-header {
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 8rpx;
+  align-items: center;
+  gap: 20rpx;
+  margin-bottom: 20rpx;
+}
+
+.avatar {
+  width: 88rpx;
+  height: 88rpx;
+  border-radius: 50%;
+  background-color: #f4f5f7;
+}
+
+.header-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8rpx;
+}
+
+.tag-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12rpx;
 }
 
 .visitor-name {
-  font-size: 28rpx;
+  font-size: 30rpx;
   font-weight: 600;
-  color: #333;
+  color: #1f2933;
 }
 
 .visit-time {
   font-size: 24rpx;
-  color: #888;
+  color: #65748b;
+}
+
+.visit-count {
+  font-size: 24rpx;
+  color: #3c6ff0;
+  background-color: rgba(60, 111, 240, 0.08);
+  padding: 8rpx 16rpx;
+  border-radius: 999rpx;
+}
+
+.auth-tag {
+  font-size: 22rpx;
+  color: #0f9d58;
+  background-color: rgba(15, 157, 88, 0.12);
+  padding: 6rpx 16rpx;
+  border-radius: 999rpx;
 }
 
 .item-content {
-  margin-bottom: 12rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  margin-bottom: 20rpx;
 }
 
-.purpose, .contact {
+.info-row {
+  display: flex;
+  gap: 16rpx;
+}
+
+.label {
+  flex-shrink: 0;
   font-size: 24rpx;
-  color: #333;
+  color: #8891a7;
 }
 
-.remark {
-  font-size: 22rpx;
-  color: #666;
+.value {
+  flex: 1;
+  font-size: 26rpx;
+  color: #333;
+  line-height: 1.4;
+  word-break: break-all;
 }
 
 .item-footer {
   display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
   justify-content: space-between;
   align-items: center;
+  border-top: 1rpx solid #f1f2f6;
+  padding-top: 16rpx;
 }
 
 .create-time {
-  font-size: 20rpx;
-  color: #aaa;
+  font-size: 22rpx;
+  color: #98a1b3;
 }
 
 .delete-btn {
   font-size: 24rpx;
-  color: #FF3B30; /* 苹果删除色 */
-  cursor: pointer;
-  transition: color 0.3s ease;
-}
-
-.delete-btn:hover {
-  color: #d9534f; /* 略微加深红色 */
+  color: #ff4d4f;
 }
 
 /* 空状态 */


### PR DESCRIPTION
## Summary
- capture and persist user authorization state on the首页, including a reusable authorization banner and smarter visit logging with device and scene metadata, while ensuring nickname updates without pulling in babel helpers
- enhance the addVisitorRecord 云函数 to upsert by openid, retain remarks, and avoid duplicate increments while exposing consistent record ids using Object.assign for兼容
- restyle the访客记录页 with richer cards, helper formatting, and total counters for easier管理, keeping分页追加兼容原生语法

## Testing
- not run (mini program tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5612136b8832cb7016b74c0f8d010