### PR TITLE
Normalize visitor record ids and restore visitor table view

### DIFF
--- a/cloudfunctions/addVisitorRecord/index.js
+++ b/cloudfunctions/addVisitorRecord/index.js
@@ -1,48 +1,125 @@
 const cloud = require('wx-server-sdk')
+
 cloud.init({ env: cloud.DYNAMIC_CURRENT_ENV }) // 使用当前云环境
+
 const db = cloud.database()
+const _ = db.command
 const visitor_records = db.collection('visitor_records')
 
+const formatUserInfo = (userInfo = {}) => {
+  if (!userInfo || typeof userInfo !== 'object') {
+    return {}
+  }
+
+  const allowKeys = ['avatarUrl', 'nickName', 'gender', 'city', 'province', 'country', 'language']
+  return allowKeys.reduce((acc, key) => {
+    if (userInfo[key] !== undefined && userInfo[key] !== null) {
+      acc[key] = userInfo[key]
+    }
+    return acc
+  }, {})
+}
+
+const normalizeId = (value) => {
+  if (!value) {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed || trimmed === 'undefined' || trimmed === 'null' || trimmed === '0' || trimmed === '[object Object]') {
+      return ''
+    }
+    return trimmed
+  }
+
+  return ''
+}
+
 exports.main = async (event) => {
-  console.log("event", event)
-  const { visitData, userInfo, remark, _id } = event
-  
-  // 如果提供了 id，则执行更新操作，否则执行添加操作
+  const { visitData = {}, userInfo, remark, _id, shouldIncrement = true } = event
+  const wxContext = cloud.getWXContext()
+  const now = db.serverDate()
+  const incrementValue = shouldIncrement ? 1 : 0
+  const normalizedId = normalizeId(_id)
+
   try {
-    let result
-    if (_id) {
-      // 更新操作
-      result = await visitor_records.doc(_id).update({
-        data: {
-          ...visitData,
-          ...userInfo,
-          remark: remark || '',
-          updateTime: db.serverDate()  // 更新操作时更新 `updateTime`
-        }
+    const safeVisitData = visitData && typeof visitData === 'object' ? visitData : {}
+    const formattedUser = formatUserInfo(userInfo)
+    const basePayload = Object.assign({}, safeVisitData, formattedUser, {
+      openid: wxContext.OPENID,
+      appid: wxContext.APPID,
+      unionid: wxContext.UNIONID || '',
+      visitTime: now,
+      updateTime: now
+    })
+
+    if (remark !== undefined && remark !== null) {
+      basePayload.remark = remark
+    }
+
+    if (Object.prototype.hasOwnProperty.call(basePayload, 'authorized')) {
+      basePayload.authorized = Boolean(basePayload.authorized)
+    }
+
+    // 优先按照传入的 _id 更新
+    const buildUpdateData = () => {
+      const updateData = Object.assign({}, basePayload)
+      if (incrementValue > 0) {
+        updateData.visitCount = _.inc(incrementValue)
+      }
+      return updateData
+    }
+
+    if (normalizedId) {
+      const updateResult = await visitor_records.doc(normalizedId).update({
+        data: buildUpdateData()
       })
+
       return {
         success: true,
-        data: result,
+        data: updateResult,
+        recordId: normalizedId,
         message: '更新成功'
       }
-    } else {
-      // 添加操作
-      result = await visitor_records.add({
-        data: {
-          ...visitData,
-          ...userInfo,
-          remark: remark || '',
-          createTime: db.serverDate(),
-          updateTime: db.serverDate()
-        }
+    }
+
+    // 若没有传入 _id，则尝试使用 openid 查询已有记录
+    const existingRecord = await visitor_records
+      .where({ openid: wxContext.OPENID })
+      .limit(1)
+      .get()
+
+    if (existingRecord.data.length) {
+      const recordId = existingRecord.data[0]._id
+      const updateResult = await visitor_records.doc(recordId).update({
+        data: buildUpdateData()
       })
+
       return {
         success: true,
-        data: result,
-        message: '添加成功'
+        data: updateResult,
+        recordId,
+        message: '更新成功'
       }
     }
+
+    // 新建访客记录
+    const createResult = await visitor_records.add({
+      data: Object.assign({}, basePayload, {
+        visitCount: incrementValue > 0 ? incrementValue : 1,
+        createTime: now
+      })
+    })
+
+    return {
+      success: true,
+      data: createResult,
+      recordId: createResult._id,
+      message: '添加成功'
+    }
   } catch (error) {
+    console.error('记录访客失败', error)
     return {
       success: false,
       message: error.message

--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -38,75 +38,22 @@ App({
 
     // 小程序启动时，初始化云开发环境
     onLaunch(options) {
-        console.log("options", options)
         !this.globalData.isRemoved && wx.cloud.init({
             env: 'cloud1-7gptyc1428d9b296', // 云开发环境ID，在云开发控制台里可以查看
             traceUser: true
         })
-        const db = wx.cloud.database()
-        const { scene, path, query, referrerInfo } = options
 
-
-
-        // 获取设备信息
-        const systemInfo = wx.getSystemInfoSync()
-
-        // 构建访问记录数据
-        const visitData = {
-            visitTime: new Date(),
-            pagePath: path || '首页',
-            scene: scene || 1001,
-            sceneInfo: this.getSceneInfo(scene),
-            deviceInfo: {
-                model: systemInfo.model,
-                system: systemInfo.system,
-                platform: systemInfo.platform,
-                SDKVersion: systemInfo.SDKVersion
-            },
-            createTime: db.serverDate()
+        const storedRecordId = wx.getStorageSync('recordId')
+        if (storedRecordId) {
+            this.globalData.recordId = storedRecordId
         }
 
-        // 如果有场景参数，添加场景信息
-        if (query) {
-            visitData.queryParams = query
+        const storedProfile = wx.getStorageSync('userProfile')
+        if (storedProfile && typeof storedProfile === 'object') {
+            this.globalData.userInfo = storedProfile
         }
 
-        // 如果有来源信息
-        if (referrerInfo) {
-            visitData.referrerInfo = referrerInfo
-        }
-
-
-        // 添加访客记录的云函数
-        wx.cloud.callFunction({
-            name: 'addVisitorRecord',
-            data: {
-                _id: null,
-                visitData: {
-                    ...visitData
-                },
-                userInfo: {
-                    "openId": "OPENID",
-                    "nickName": "NICKNAME",
-                    "gender": "GENDER",
-                    "city": "CITY",
-                    "province": "PROVINCE",
-                    "country": "COUNTRY",
-                    "avatarUrl": "AVATARURL",
-                    "unionId": "UNIONID",
-                }
-            }
-        }).then((res)=>{
-          console.log("res", res)
-          if(res.result.data.errMsg === 'collection.add:ok'){
-            console.log("res", res.result.data._id)
-            this.globalData.recordId = res.result.data._id
-            wx.setStorageSync('recordId', res.result.data._id);
-
-          }
-          
-        })
-
+        this.globalData.launchOptions = options
     },
 
     // 小程序可见时，判断是否为单页模式

--- a/miniprogram/pages/index/index.js
+++ b/miniprogram/pages/index/index.js
@@ -6,14 +6,52 @@ const {
 const MANAGER = ['ohop817Bj849OhyAbLAxxBloH7RQ']
 
 const APP = getApp()
-const isRemoved = APP.globalData.isRemoved
+const GLOBAL_DATA = (APP && APP.globalData) ? APP.globalData : {}
+const INITIAL_IS_REMOVED = !!GLOBAL_DATA.isRemoved
+const normalizeRecordId = (value) => {
+    if (!value) {
+        return ''
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim()
+        if (!trimmed || trimmed === 'undefined' || trimmed === 'null' || trimmed === '0' || trimmed === '[object Object]') {
+            return ''
+        }
+        return trimmed
+    }
+
+    return ''
+}
+
 Page({
     data: {
-        ...APP.globalData,
+        isSinglePage: typeof GLOBAL_DATA.isSinglePage === 'boolean' ? GLOBAL_DATA.isSinglePage : null,
+        recordId: normalizeRecordId(GLOBAL_DATA.recordId) || null,
+        isRemoved: INITIAL_IS_REMOVED,
+        magic: typeof GLOBAL_DATA.magic === 'boolean' ? GLOBAL_DATA.magic : false,
+        weddingTime: GLOBAL_DATA.weddingTime || '2025-10-04 11:30',
+        couple: GLOBAL_DATA.couple || [{
+            image: 'https://h5cdn.hunbei.com/editorTempCustomPic/2025-9-20-jPciJQEZrC6fh7HYhNpZ2dNWDDkbEHXS.jpeg',
+            name: '张家宾',
+            alias: '新郎',
+            number: '16602187434',
+            birthday: '1997.01.30'
+        }, {
+            image: 'https://h5cdn.hunbei.com/editorTempCustomPic/2025-9-20-bwCWsARrGE8zr2cSNwKDHBNw6zBKTEde.jpeg',
+            name: '张宇',
+            alias: '新娘',
+            number: '打新郎的',
+            birthday: '1996.10.16'
+        }],
+        publisher: GLOBAL_DATA.publisher || '家宾&小宇',
+        anniversary: GLOBAL_DATA.anniversary || '2020.10.08',
         userInfo: null,
+        hasAuthorized: false,
+        showAuthPrompt: false,
         isManager: false, // 当前用户是否为管理员
         musicIsPaused: false, // 是否暂停背景音乐
-        activeIdx: isRemoved ? 0 : -1, // 祝福语轮播用，当前显示的祝福语索引值
+        activeIdx: INITIAL_IS_REMOVED ? 0 : -1, // 祝福语轮播用，当前显示的祝福语索引值
         form: { // 表单信息
             name: '',
             num: '',
@@ -28,7 +66,7 @@ Page({
         showEggs: false,
 
         // 祝福语列表
-        greetings: isRemoved ? [
+        greetings: INITIAL_IS_REMOVED ? [
             // 云开发下架后显示的祝福语数据，可以在云开发环境销毁前把数据库的数据导出来并贴到这里
             {
                 name: '新郎 & 新娘',
@@ -125,38 +163,54 @@ Page({
 
     // 小程序加载时，拉取表单信息并填充，以及格式化各种婚礼时间
     onLoad() {
-          // 假设云函数更新了 magic 数据
-   
-                // 添加访客记录的云函数
-                wx.cloud.callFunction({
-                  name: 'system_config',
-                  data: {
-                  }
-              }).then(result => {
-                
-                if (result.errMsg === 'cloud.callFunction:ok') {
-                  let config = result.result[0]
-            
-                  this.setData({
+        // 假设云函数更新了 magic 数据
+        wx.cloud.callFunction({
+            name: 'system_config',
+            data: {}
+        }).then(result => {
+            if (result.errMsg === 'cloud.callFunction:ok') {
+                const config = result.result[0]
+
+                this.setData({
                     magic: config.magic,
                     isRemoved: config.isRemoved
-                  });
-                  
-                }else{
-        
+                })
+
+                if (APP && APP.globalData) {
+                    APP.globalData.magic = config.magic
+                    APP.globalData.isRemoved = config.isRemoved
                 }
-        
-                return result;
-              })
+            }
 
+            return result
+        })
 
-        
         this.timer = null
         this.music = null
         this.isSubmit = false
+        this.recording = false
+        this.pendingRecord = null
 
-        if (!isRemoved) {
-          
+        this.initUserInfo()
+
+        const cachedRecordId = normalizeRecordId(wx.getStorageSync('recordId') || this.data.recordId || (APP && APP.globalData && APP.globalData.recordId))
+        if (cachedRecordId) {
+            if (this.data.recordId !== cachedRecordId) {
+                this.setData({
+                    recordId: cachedRecordId
+                })
+            }
+            if (APP && APP.globalData) {
+                APP.globalData.recordId = cachedRecordId
+            }
+        } else if (this.data.recordId) {
+            this.setData({
+                recordId: null
+            })
+        }
+
+        if (!this.data.isRemoved) {
+
             const db = wx.cloud.database()
             db.collection('surveys').get({
                 success: res => {
@@ -208,78 +262,17 @@ Page({
 
     // 小程序可见时，拉取祝福语，并设置定时器每20s重新拉取一次祝福语
     onShow() {
-      wx.showModal({
-        title: '温馨提示',
-        content: '亲，授权微信登录后才能正常使用小程序功能',
-        success: (res)=> {
-          console.log(0)
-          console.log(res)
-          //如果用户点击了确定按钮
-          if (res.confirm) {
-            wx.getUserProfile({
-              desc: '获取你的昵称、头像、地区及性别',
-              success: res => {
-                console.log(res);
-                this.setData({userInfo: res.userInfo})
-            //     this.setData({
-            //       form: {
-            //           ...this.data.form,
-            //           name: res.userInfo.nickName,
-            //           avatarUrl: res.userInfo.avatarUrl
-            //       }
-            //   });
-                console.log(1);
-              },
-              fail: res => {
-                console.log(2);
-                console.log(res)
-                //拒绝授权
-                wx.showToast({
-                  title: '您拒绝了请求,不能正常使用小程序',
-                  icon: 'error',
-                  duration: 2000
-                });
-                return;
-              }
-            });
-          } else if (res.cancel) {
-            //如果用户点击了取消按钮
-            console.log(3);
-            wx.showToast({
-              title: '您拒绝了请求,不能正常使用小程序',
-              icon: 'error',
-              duration: 2000
-            });
-            return;
-          }
-        }
-      });
-      
-        if (!isRemoved) {
+        if (!this.data.isRemoved) {
             this.getGreetings()
 
             this.timer === null && (this.timer = setInterval(() => this.getGreetings(), 20000));
         }
-        const recordId = wx.getStorageSync('recordId') || '';
-        console.log("APP.globalData.recordId", recordId, this.userInfo)
 
-        wx.cloud.callFunction({
-          name: 'addVisitorRecord',
-          data: {
-            _id: recordId,
-            userInfo: {
-              nickName: 'John Doe',
-              openId: '123456789'
-            },
-          },
-          success(res) {
-            console.log('Success:', res)
-          },
-          fail(err) {
-            console.log('Error:', err)
-          }
-        })
-        
+        if (!this.data.hasAuthorized && !this.data.showAuthPrompt) {
+            this.setData({ showAuthPrompt: true })
+        }
+
+        this.recordVisit()
     },
 
     // 小程序不可见时，取消自动拉取祝福语定时器
@@ -399,7 +392,7 @@ Page({
                     icon: 'error'
                 })
             } else {
-                if (isRemoved) {
+                if (this.data.isRemoved) {
                     wx.showToast({
                         title: '婚礼结束了哦~'
                     })
@@ -513,11 +506,205 @@ Page({
             url: `../record/index?isManager=${this.data.isManager}`
         })
     },
+    handleAuthorize() {
+        if (typeof wx.getUserProfile !== 'function') {
+            wx.showToast({
+                title: '当前微信版本过低，无法授权',
+                icon: 'none'
+            })
+            return
+        }
+        wx.getUserProfile({
+            desc: '用于展示访客头像和昵称，并同步访客记录',
+            success: (res) => {
+                const userInfo = res.userInfo || {}
+                const storedForm = Object.assign({}, this.data.form || {})
+
+                if (!storedForm.name && userInfo.nickName) {
+                    storedForm.name = userInfo.nickName
+                }
+
+                if (!storedForm.avatarUrl && userInfo.avatarUrl) {
+                    storedForm.avatarUrl = userInfo.avatarUrl
+                }
+
+                wx.setStorageSync('userProfile', userInfo)
+                APP.globalData.userInfo = userInfo
+
+                this.setData({
+                    userInfo,
+                    hasAuthorized: true,
+                    showAuthPrompt: false,
+                    form: storedForm
+                }, () => {
+                    this.recordVisit({ force: true, increment: false })
+                })
+            },
+            fail: () => {
+                wx.showToast({
+                    title: '授权已取消',
+                    icon: 'none'
+                })
+            }
+        })
+    },
+    initUserInfo() {
+        const storedProfile = wx.getStorageSync('userProfile')
+        const cached = APP.globalData.userInfo || (typeof storedProfile === 'object' ? storedProfile : null)
+        if (cached && typeof cached === 'object' && Object.keys(cached).length) {
+            const storedForm = Object.assign({}, this.data.form || {})
+
+            if (!storedForm.name && cached.nickName) {
+                storedForm.name = cached.nickName
+            }
+
+            if (!storedForm.avatarUrl && cached.avatarUrl) {
+                storedForm.avatarUrl = cached.avatarUrl
+            }
+
+            this.setData({
+                userInfo: cached,
+                hasAuthorized: true,
+                showAuthPrompt: false,
+                form: storedForm
+            })
+            APP.globalData.userInfo = cached
+        } else {
+            const canAuthorize = typeof wx.getUserProfile === 'function'
+            this.setData({
+                hasAuthorized: false,
+                showAuthPrompt: canAuthorize
+            })
+        }
+    },
+    recordVisit(options = {}) {
+        if (APP.globalData.isRemoved) {
+            return
+        }
+
+        if (!wx.cloud || typeof wx.cloud.callFunction !== 'function') {
+            console.warn('云开发未初始化，无法记录访客信息')
+            return
+        }
+
+        let force = false
+        let increment = true
+
+        if (typeof options === 'boolean') {
+            force = options
+        } else if (options && typeof options === 'object') {
+            force = !!options.force
+            if (options.increment === false) {
+                increment = false
+            }
+        }
+
+        if (this.recording) {
+            if (force) {
+                this.pendingRecord = { force: false, increment }
+            }
+            return
+        }
+
+        let launchOptions = {}
+        try {
+            launchOptions = wx.getLaunchOptionsSync ? wx.getLaunchOptionsSync() : {}
+        } catch (error) {
+            launchOptions = {}
+        }
+
+        if ((!launchOptions || Object.keys(launchOptions).length === 0) && APP.globalData.launchOptions) {
+            launchOptions = APP.globalData.launchOptions
+        }
+
+        const sceneDescription = typeof APP.getSceneInfo === 'function'
+            ? APP.getSceneInfo(launchOptions.scene)
+            : ''
+
+        let systemInfo = {}
+        try {
+            systemInfo = wx.getSystemInfoSync()
+        } catch (error) {
+            systemInfo = {}
+        }
+
+        const visitData = {
+            sceneInfo: {
+                scene: launchOptions.scene,
+                path: launchOptions.path,
+                query: launchOptions.query || {},
+                referrerInfo: launchOptions.referrerInfo || {},
+                description: sceneDescription
+            },
+            deviceInfo: {
+                brand: systemInfo.brand,
+                model: systemInfo.model,
+                system: systemInfo.system,
+                version: systemInfo.version,
+                platform: systemInfo.platform,
+                language: systemInfo.language
+            },
+            pagePath: launchOptions.path || 'pages/index/index',
+            authorized: this.data.hasAuthorized,
+            clientTime: new Date().toISOString()
+        }
+
+        const storedRecordId = normalizeRecordId(wx.getStorageSync('recordId'))
+        const currentRecordId = normalizeRecordId(this.data.recordId)
+        const globalRecordId = normalizeRecordId(APP && APP.globalData && APP.globalData.recordId)
+        const recordId = storedRecordId || currentRecordId || globalRecordId
+        const userInfo = this.data.userInfo || {}
+        const formData = this.data.form || {}
+        const fallbackName = formData.name || '未留名访客'
+        const fallbackAvatar = formData.avatarUrl || ''
+
+        const payloadUserInfo = Object.assign({}, userInfo, {
+            nickName: userInfo.nickName || fallbackName,
+            avatarUrl: userInfo.avatarUrl || fallbackAvatar
+        })
+
+        this.recording = true
+        wx.cloud.callFunction({
+            name: 'addVisitorRecord',
+            data: {
+                _id: recordId || undefined,
+                visitData,
+                userInfo: payloadUserInfo,
+                shouldIncrement: increment
+            }
+        }).then((res) => {
+            const { result } = res || {}
+            if (result && result.success && result.recordId) {
+                const normalized = normalizeRecordId(result.recordId)
+                if (normalized) {
+                    wx.setStorageSync('recordId', normalized)
+                    if (APP && APP.globalData) {
+                        APP.globalData.recordId = normalized
+                    }
+                    if (this.data.recordId !== normalized) {
+                        this.setData({
+                            recordId: normalized
+                        })
+                    }
+                }
+            }
+        }).catch((error) => {
+            console.error('记录访客失败', error)
+        }).finally(() => {
+            this.recording = false
+            if (this.pendingRecord) {
+                const pendingOptions = this.pendingRecord
+                this.pendingRecord = null
+                this.recordVisit(pendingOptions)
+            }
+        })
+    },
     onChooseAvatar(e) {
-      const { avatarUrl } = e.detail 
+      const { avatarUrl } = e.detail
       this.setData({
         'form.avatarUrl':avatarUrl,
       })
+      this.recordVisit({ force: true, increment: false })
     }
-      
+
 })

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -31,6 +31,11 @@
     </view>
 </view>
 
+<view wx:if="{{ showAuthPrompt }}" class="auth-banner">
+    <view class="auth-text">授权后可同步头像昵称并记录访客信息，方便后续查看。</view>
+    <button class="auth-btn" bindtap="handleAuthorize">微信快捷授权</button>
+</view>
+
 <view class="tc lh21 mb58">
     <view>hi~亲爱的你~</view>
     <view>当收到这封请柬的时候</view>
@@ -227,7 +232,7 @@
         <view>
             <textarea type="text" placeholder="祝福语，可以上墙哦~" name="greeting" value="{{ form.greeting }}" placeholder-class="form-input-placeholder" maxlength="140" disable-default-padding />
         </view>
-        <button form-type="submit" open-type="getUserInfo" >{{ form.name ? '更新' : '提交' }}</button>
+        <button form-type="submit">{{ form.name ? '更新' : '提交' }}</button>
     </view>
 </form>
 

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -131,6 +131,35 @@
     align-items: flex-end;
 }
 
+.auth-banner {
+    margin: 0 40rpx 60rpx;
+    padding: 24rpx 28rpx;
+    background: linear-gradient(135deg, #f3f9ff, #fff);
+    border-radius: 20rpx;
+    box-shadow: 0 8rpx 24rpx rgba(39, 92, 255, 0.08);
+}
+
+.auth-text {
+    font-size: 26rpx;
+    color: #344563;
+    line-height: 1.6;
+}
+
+.auth-btn {
+    margin-top: 20rpx;
+    background-color: #07c160;
+    color: #fff;
+    border-radius: 999rpx;
+    font-size: 28rpx;
+    padding: 12rpx 0;
+    width: 100%;
+    font-weight: 600;
+}
+
+.auth-btn::after {
+    border: none;
+}
+
 .music-status {
     width: 32rpx;
     height: 22rpx;

--- a/miniprogram/pages/record/index.js
+++ b/miniprogram/pages/record/index.js
@@ -7,7 +7,10 @@ Page({
       page: 1,
       pageSize: 20,
       keyword: '',
-      userInfo: null
+      userInfo: null,
+      totalCount: 0,
+      defaultAvatar: 'https://res.wx.qq.com/a/wx_fed/assets/res/OTE0YTAw.png',
+      viewMode: 'table'
     },
   
     onLoad(options) {
@@ -91,7 +94,8 @@ Page({
             visitorList: result.data,
             page: 1,
             hasMore: result.data.length < result.total,
-            loading: false
+            loading: false,
+            totalCount: result.total
           })
         } else {
           wx.showToast({
@@ -128,10 +132,11 @@ Page({
         
         if (result.success) {
           this.setData({
-            visitorList: [...this.data.visitorList, ...result.data],
+            visitorList: this.data.visitorList.concat(result.data),
             page: this.data.page + 1,
             hasMore: (this.data.page + 1) * this.data.pageSize < result.total,
-            loading: false
+            loading: false,
+            totalCount: result.total
           })
         } else {
           this.setData({ loading: false })
@@ -162,9 +167,94 @@ Page({
     },
   
     // 格式化时间显示
-    formatTime(dateString) {
-      const date = new Date(dateString)
-      return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')} ${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`
+    formatTime(dateInput) {
+      if (!dateInput) {
+        return '--'
+      }
+
+      const date = dateInput instanceof Date ? dateInput : new Date(dateInput)
+      if (Number.isNaN(date.getTime())) {
+        return '--'
+      }
+
+      const pad = (value) => value.toString().padStart(2, '0')
+      return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`
+    },
+
+    switchView(e) {
+      const { mode } = e.currentTarget.dataset || {}
+      if (!mode || mode === this.data.viewMode) {
+        return
+      }
+
+      this.setData({
+        viewMode: mode
+      })
+    },
+
+    formatDeviceInfo(deviceInfo) {
+      if (!deviceInfo || typeof deviceInfo !== 'object') {
+        return '未获取到设备信息'
+      }
+
+      const parts = []
+      if (deviceInfo.brand) {
+        parts.push(deviceInfo.brand)
+      }
+      if (deviceInfo.model) {
+        parts.push(deviceInfo.model)
+      }
+      if (deviceInfo.system) {
+        parts.push(deviceInfo.system)
+      }
+      if (deviceInfo.version) {
+        parts.push(`版本 ${deviceInfo.version}`)
+      }
+      if (deviceInfo.platform) {
+        parts.push(`平台 ${deviceInfo.platform}`)
+      }
+      return parts.join(' · ') || '未获取到设备信息'
+    },
+
+    formatSceneInfo(sceneInfo) {
+      if (!sceneInfo) {
+        return '直接打开'
+      }
+
+      if (typeof sceneInfo === 'string') {
+        return sceneInfo
+      }
+
+      const { scene, path, query = {}, referrerInfo = {}, description, pagePath } = sceneInfo
+      const info = []
+
+      if (description) {
+        info.push(description)
+      }
+
+      if (scene !== undefined) {
+        info.push(`场景值 ${scene}`)
+      }
+
+      if (path) {
+        info.push(path)
+      }
+
+      if (pagePath) {
+        info.push(`页面 ${pagePath}`)
+      }
+
+      const queryKeys = Object.keys(query || {})
+      if (queryKeys.length) {
+        const queryString = queryKeys.map(key => `${key}=${query[key]}`).join('&')
+        info.push(`参数 ${queryString}`)
+      }
+
+      if (referrerInfo.appId) {
+        info.push(`来源小程序 ${referrerInfo.appId}`)
+      }
+
+      return info.join(' | ') || '直接打开'
     },
   
     // 删除记录（需要额外权限验证）

--- a/miniprogram/pages/record/index.wxml
+++ b/miniprogram/pages/record/index.wxml
@@ -23,14 +23,28 @@
 
     <!-- 统计信息 -->
     <view class="stats">
-      <text class="welcome-text">欢迎，{{userInfo.name}}</text>
-      <text class="stats-text">共{{visitorList.length}}条记录</text>
+      <text class="welcome-text">欢迎，{{userInfo && userInfo.name ? userInfo.name : '管理员'}}</text>
+      <text class="stats-text">共{{totalCount}}条记录</text>
+    </view>
+
+    <!-- 视图切换 -->
+    <view class="view-switch">
+      <view
+        class="switch-button {{viewMode === 'table' ? 'active' : ''}}"
+        data-mode="table"
+        bindtap="switchView"
+      >表格视图</view>
+      <view
+        class="switch-button {{viewMode === 'cards' ? 'active' : ''}}"
+        data-mode="cards"
+        bindtap="switchView"
+      >卡片视图</view>
     </view>
 
     <!-- 访客列表 -->
-    <scroll-view 
-      class="record-list" 
-      scroll-y 
+    <scroll-view
+      class="record-list"
+      scroll-y
       bindscrolltolower="onReachBottom"
     >
       <view wx:if="{{visitorList.length === 0 && !loading}}" class="empty">
@@ -38,21 +52,87 @@
         <text class="empty-text">{{keyword ? '暂无搜索结果' : '暂无访客记录'}}</text>
       </view>
 
-      <view wx:for="{{visitorList}}" wx:key="_id" class="record-item">
-        <view class="item-header">
-          <text class="visitor-name">{{item.sceneInfo}}</text>
-          <text class="visit-time">{{formatTime(item.visitTime)}}</text>
+      <block wx:if="{{viewMode === 'table' && visitorList.length}}">
+        <view class="record-table">
+          <view class="table-header">
+            <view class="cell cell-visitor">访客</view>
+            <view class="cell cell-auth">授权状态</view>
+            <view class="cell cell-count">访问次数</view>
+            <view class="cell cell-time">最近访问</view>
+            <view class="cell cell-time">首次访问</view>
+            <view class="cell cell-device">设备信息</view>
+            <view class="cell cell-scene">访问入口</view>
+            <view class="cell cell-remark">备注</view>
+            <view class="cell cell-actions">操作</view>
+          </view>
+          <block wx:for="{{visitorList}}" wx:key="_id">
+            <view class="table-row">
+              <view class="cell cell-visitor">
+                <view class="visitor-cell">
+                  <image class="avatar" src="{{item.avatarUrl || defaultAvatar}}" mode="aspectFill"></image>
+                  <view class="visitor-meta">
+                    <text class="visitor-name">{{item.nickName || '未授权访客'}}</text>
+                    <text class="visit-time">最近访问：{{formatTime(item.visitTime)}}</text>
+                  </view>
+                </view>
+              </view>
+              <view class="cell cell-auth">
+                <text class="auth-status {{item.authorized ? 'is-auth' : 'is-unauth'}}">{{item.authorized ? '已授权' : '未授权'}}</text>
+              </view>
+              <view class="cell cell-count">{{item.visitCount || 0}}</view>
+              <view class="cell cell-time">{{formatTime(item.visitTime)}}</view>
+              <view class="cell cell-time">{{formatTime(item.createTime)}}</view>
+              <view class="cell cell-device">{{formatDeviceInfo(item.deviceInfo)}}</view>
+              <view class="cell cell-scene">{{formatSceneInfo(item.sceneInfo)}}</view>
+              <view class="cell cell-remark">{{item.remark || '--'}}</view>
+              <view class="cell cell-actions">
+                <text class="delete-btn" bindtap="deleteRecord" data-id="{{item._id}}">删除</text>
+              </view>
+            </view>
+          </block>
         </view>
-        <view class="item-content">
-          <text class="purpose">头像：{{item.avatarUrl}}</text>
-          <text class="contact">昵称：{{item.nickName}}</text>
-          <text wx:if="{{item.deviceInfo}}" class="remark">备注：{{stringify(item.deviceInfo)}}</text>
+      </block>
+
+      <block wx:elif="{{viewMode === 'cards' && visitorList.length}}">
+        <view wx:for="{{visitorList}}" wx:key="_id" class="record-item">
+          <view class="item-header">
+            <image class="avatar" src="{{item.avatarUrl || defaultAvatar}}" mode="aspectFill"></image>
+            <view class="header-main">
+              <text class="visitor-name">{{item.nickName || '未授权访客'}}</text>
+              <text class="visit-time">最近访问：{{formatTime(item.visitTime)}}</text>
+            </view>
+            <view class="tag-group">
+              <view wx:if="{{item.visitCount}}" class="visit-count">第{{item.visitCount}}次</view>
+              <view wx:if="{{item.authorized}}" class="auth-tag">已授权</view>
+            </view>
+          </view>
+
+          <view class="item-content">
+            <view class="info-row">
+              <text class="label">访问入口</text>
+              <text class="value">{{formatSceneInfo(item.sceneInfo)}}</text>
+            </view>
+            <view class="info-row">
+              <text class="label">设备信息</text>
+              <text class="value">{{formatDeviceInfo(item.deviceInfo)}}</text>
+            </view>
+            <view class="info-row" wx:if="{{item.clientTime}}">
+              <text class="label">客户端</text>
+              <text class="value">{{formatTime(item.clientTime)}}</text>
+            </view>
+            <view class="info-row" wx:if="{{item.remark}}">
+              <text class="label">备注</text>
+              <text class="value">{{item.remark}}</text>
+            </view>
+          </view>
+
+          <view class="item-footer">
+            <text class="create-time">首次访问：{{formatTime(item.createTime)}}</text>
+            <text class="create-time">最近更新：{{formatTime(item.updateTime || item.visitTime)}} </text>
+            <text class="delete-btn" bindtap="deleteRecord" data-id="{{item._id}}">删除</text>
+          </view>
         </view>
-        <view class="item-footer">
-          <text class="create-time">记录时间：{{formatTime(item.createTime)}}</text>
-          <text class="delete-btn" bindtap="deleteRecord" data-id="{{item._id}}">删除</text>
-        </view>
-      </view>
+      </block>
 
       <!-- 加载状态 -->
       <view wx:if="{{loading}}" class="loading">加载中...</view>

--- a/miniprogram/pages/record/index.wxss
+++ b/miniprogram/pages/record/index.wxss
@@ -83,78 +83,254 @@
   color: #666;
 }
 
+.view-switch {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12rpx;
+  padding: 12rpx 20rpx 0;
+  background-color: #fff;
+}
+
+.switch-button {
+  padding: 12rpx 24rpx;
+  border-radius: 999rpx;
+  font-size: 24rpx;
+  color: #65748b;
+  background-color: #eef1f6;
+}
+
+.switch-button.active {
+  color: #fff;
+  background-color: #3c6ff0;
+  box-shadow: 0 6rpx 12rpx rgba(60, 111, 240, 0.2);
+}
+
 /* 访客列表 */
 .record-list {
-  max-height: 600rpx;
+  height: calc(100vh - 320rpx);
   overflow-y: auto;
-  padding-bottom: 60rpx; /* 为了scroll-view添加空间 */
+  padding: 0 16rpx 60rpx;
+}
+
+.record-table {
+  width: 100%;
+  background-color: #fff;
+  border-radius: 16rpx;
+  overflow: hidden;
+  border: 1rpx solid #e0e0e0;
+  margin-bottom: 20rpx;
+}
+
+.table-header,
+.table-row {
+  display: flex;
+  align-items: stretch;
+}
+
+.table-header {
+  background-color: #f5f7fa;
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.cell {
+  flex: 1;
+  padding: 20rpx 16rpx;
+  font-size: 24rpx;
+  color: #333;
+  box-sizing: border-box;
+  border-bottom: 1rpx solid #eef0f4;
+}
+
+.table-header .cell {
+  border-bottom: none;
+}
+
+.table-row:last-child .cell {
+  border-bottom: none;
+}
+
+.cell-visitor {
+  flex: 1.4;
+  min-width: 220rpx;
+}
+
+.cell-auth {
+  flex: 0.8;
+  min-width: 150rpx;
+}
+
+.cell-count {
+  flex: 0.6;
+  min-width: 140rpx;
+}
+
+.cell-time {
+  flex: 1;
+  min-width: 200rpx;
+}
+
+.cell-device {
+  flex: 1.2;
+  min-width: 260rpx;
+}
+
+.cell-scene {
+  flex: 1.3;
+  min-width: 260rpx;
+}
+
+.cell-remark {
+  flex: 1;
+  min-width: 200rpx;
+}
+
+.cell-actions {
+  flex: 0.6;
+  min-width: 140rpx;
+  text-align: right;
+}
+
+.visitor-cell {
+  display: flex;
+  align-items: center;
+  gap: 16rpx;
+}
+
+.visitor-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8rpx;
+}
+
+.auth-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 112rpx;
+  padding: 6rpx 16rpx;
+  border-radius: 999rpx;
+  font-size: 22rpx;
+  line-height: 1.4;
+}
+
+.auth-status.is-auth {
+  color: #0f9d58;
+  background-color: rgba(15, 157, 88, 0.12);
+}
+
+.auth-status.is-unauth {
+  color: #a19b9b;
+  background-color: rgba(161, 155, 155, 0.16);
 }
 
 .record-item {
   background-color: #fff;
   margin: 12rpx 0;
-  padding: 16rpx;
-  border-radius: 12rpx;
-  box-shadow: 0 3rpx 10rpx rgba(0, 0, 0, 0.05);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.record-item:hover {
-  transform: translateY(-5rpx);
-  box-shadow: 0 4rpx 12rpx rgba(0, 0, 0, 0.1);
+  padding: 24rpx;
+  border-radius: 16rpx;
+  box-shadow: 0 4rpx 16rpx rgba(0, 0, 0, 0.06);
 }
 
 .item-header {
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 8rpx;
+  align-items: center;
+  gap: 20rpx;
+  margin-bottom: 20rpx;
+}
+
+.avatar {
+  width: 88rpx;
+  height: 88rpx;
+  border-radius: 50%;
+  background-color: #f4f5f7;
+}
+
+.header-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8rpx;
+}
+
+.tag-group {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12rpx;
 }
 
 .visitor-name {
-  font-size: 28rpx;
+  font-size: 30rpx;
   font-weight: 600;
-  color: #333;
+  color: #1f2933;
 }
 
 .visit-time {
   font-size: 24rpx;
-  color: #888;
+  color: #65748b;
+}
+
+.visit-count {
+  font-size: 24rpx;
+  color: #3c6ff0;
+  background-color: rgba(60, 111, 240, 0.08);
+  padding: 8rpx 16rpx;
+  border-radius: 999rpx;
+}
+
+.auth-tag {
+  font-size: 22rpx;
+  color: #0f9d58;
+  background-color: rgba(15, 157, 88, 0.12);
+  padding: 6rpx 16rpx;
+  border-radius: 999rpx;
 }
 
 .item-content {
-  margin-bottom: 12rpx;
+  display: flex;
+  flex-direction: column;
+  gap: 16rpx;
+  margin-bottom: 20rpx;
 }
 
-.purpose, .contact {
+.info-row {
+  display: flex;
+  gap: 16rpx;
+}
+
+.label {
+  flex-shrink: 0;
   font-size: 24rpx;
-  color: #333;
+  color: #8891a7;
 }
 
-.remark {
-  font-size: 22rpx;
-  color: #666;
+.value {
+  flex: 1;
+  font-size: 26rpx;
+  color: #333;
+  line-height: 1.4;
+  word-break: break-all;
 }
 
 .item-footer {
   display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
   justify-content: space-between;
   align-items: center;
+  border-top: 1rpx solid #f1f2f6;
+  padding-top: 16rpx;
 }
 
 .create-time {
-  font-size: 20rpx;
-  color: #aaa;
+  font-size: 22rpx;
+  color: #98a1b3;
 }
 
 .delete-btn {
   font-size: 24rpx;
-  color: #FF3B30; /* 苹果删除色 */
-  cursor: pointer;
-  transition: color 0.3s ease;
-}
-
-.delete-btn:hover {
-  color: #d9534f; /* 略微加深红色 */
+  color: #ff4d4f;
 }
 
 /* 空状态 */


### PR DESCRIPTION
## Summary
- normalize cached visitor record ids on the index page before calling the cloud function to avoid updating with placeholder values
- harden the addVisitorRecord cloud function by sanitizing incoming ids, skipping empty increments, and preserving the first visit count
- restore a tabbed manager UI with both table and card views for visitor records, including styles for the table layout

## Testing
- not run (mini program tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5612136b8832cb7016b74c0f8d010